### PR TITLE
fix: passed existing_cos_instance_crn variable to cos module and added variable to skip cos-kms iam auth policy in standard solution

### DIFF
--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -85,6 +85,8 @@ module "cos" {
   version                             = "8.3.2"
   create_cos_instance                 = var.existing_cos_instance_crn == null ? true : false
   create_cos_bucket                   = var.existing_cos_bucket_name == null ? true : false
+  existing_cos_instance_id            = var.existing_cos_instance_crn
+  skip_iam_authorization_policy       = var.skip_cos_kms_auth_policy
   add_bucket_name_suffix              = var.add_bucket_name_suffix
   resource_group_id                   = module.resource_group.resource_group_id
   region                              = local.cos_bucket_region

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -176,6 +176,12 @@ variable "skip_en_cos_auth_policy" {
   default     = false
 }
 
+variable "skip_cos_kms_auth_policy" {
+  type        = bool
+  description = "Whether an IAM authorization policy is created for your Cloud Object Storage instance to read the encryption key from the KMS instance. Set to `true` to use an existing policy."
+  default     = false
+}
+
 variable "cos_instance_name" {
   type        = string
   default     = "base-security-services-cos"


### PR DESCRIPTION
### Description
Bug fixes
i) existing cos instance crn was not passed to cos module
ii) there was no option to skip cos-kms auth policy, we need to skip it if there exists an existing policy (eg. when using existing cos instance created by obs da in core security services stack)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

passed existing_cos_instance_crn variable to cos module and added variable to skip cos-kms iam auth policy in standard solution

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
