### PR TITLE
feat: added functionality to allow for a kms key in an external account

### DIFF
--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -19,7 +19,7 @@ locals {
   parsed_existing_kms_instance_crn = var.existing_kms_instance_crn != null ? split(":", var.existing_kms_instance_crn) : []
   kms_region                       = length(local.parsed_existing_kms_instance_crn) > 0 ? local.parsed_existing_kms_instance_crn[5] : null
   kms_instance_guid                = var.existing_kms_instance_crn != null ? element(split(":", var.existing_kms_instance_crn), length(split(":", var.existing_kms_instance_crn)) - 3) : module.kms[0].kms_instance_guid
-  apply_auth_policy                = (!var.skip_en_kms_auth_policy && !var.skip_en_cos_auth_policy && var.ibmcloud_kms_api_key != null) ? 1 : 0 # TODO verify this logic
+  apply_auth_policy                = (!var.skip_en_kms_auth_policy && !var.skip_cos_kms_auth_policy && var.ibmcloud_kms_api_key != null) ? 1 : 0 # TODO verify this logic
   existing_kms_guid                = var.existing_kms_instance_crn != null ? element(split(":", var.existing_kms_instance_crn), length(split(":", var.existing_kms_instance_crn)) - 3) : tobool("The CRN of the existing KMS is not provided.")
   en_key_name                      = var.prefix != null ? "${var.prefix}-${var.en_key_name}" : var.en_key_name
   en_key_ring_name                 = var.prefix != null ? "${var.prefix}-${var.en_key_ring_name}" : var.en_key_ring_name
@@ -135,7 +135,7 @@ module "cos" {
   create_cos_instance                 = var.existing_cos_instance_crn == null ? true : false
   create_cos_bucket                   = var.existing_cos_bucket_name == null ? true : false
   existing_cos_instance_id            = var.existing_cos_instance_crn
-  skip_iam_authorization_policy       = var.skip_cos_kms_auth_policy
+  skip_iam_authorization_policy       = local.apply_auth_policy == 1 ? true : false
   add_bucket_name_suffix              = var.add_bucket_name_suffix
   resource_group_id                   = module.resource_group.resource_group_id
   region                              = local.cos_bucket_region
@@ -185,6 +185,6 @@ module "event_notifications" {
   cos_destination_name    = var.cos_destination_name
   cos_bucket_name         = local.cos_bucket_name_with_suffix
   cos_instance_id         = local.cos_instance_guid
-  skip_en_cos_auth_policy = local.apply_auth_policy == 1 ? true : false
+  skip_en_cos_auth_policy = var.skip_en_cos_auth_policy
   cos_endpoint            = local.cos_endpoint
 }

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -53,14 +53,14 @@ resource "ibm_iam_authorization_policy" "cos_kms_policy" {
   description                 = "Allow the COS instance with GUID ${local.cos_instance_guid} reader access to the kms_service instance GUID ${local.existing_kms_guid}"
 }
 
-# Create IAM Authorization Policy to allow COS to access KMS for the encryption key
+# Create IAM Authorization Policy to allow EN to access KMS for the encryption key
 resource "ibm_iam_authorization_policy" "en_kms_policy" {
   count = local.apply_auth_policy
   # Conditionals with providers aren't possible, using ibm.kms as provider incase cross account is enabled
   provider                    = ibm.kms
   source_service_account      = data.ibm_iam_account_settings.iam_account_settings[0].account_id
   source_service_name         = "event-notifications"
-  source_resource_instance_id = local.cos_instance_guid
+  source_resource_instance_id = module.event_notifications.guid
   target_service_name         = local.kms_service
   target_resource_instance_id = local.existing_kms_guid
   roles                       = ["Reader"]

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -20,7 +20,7 @@ locals {
   kms_region                       = length(local.parsed_existing_kms_instance_crn) > 0 ? local.parsed_existing_kms_instance_crn[5] : null
   en_kms_key_id                    = local.existing_kms_root_key_id != null ? local.existing_kms_root_key_id : module.kms[0].keys[format("%s.%s", var.en_key_ring_name, var.en_key_name)].key_id
   kms_instance_guid                = var.existing_kms_instance_crn != null ? element(split(":", var.existing_kms_instance_crn), length(split(":", var.existing_kms_instance_crn)) - 3) : module.kms[0].kms_instance_guid
-  apply_auth_policy                = var.skip_cos_kms_auth_policy ? 0 : 1
+  apply_auth_policy                = (!var.skip_en_kms_auth_policy && var.ibmcloud_kms_api_key != null) ? 1 : 0
   existing_kms_guid                = var.existing_kms_instance_crn != null ? element(split(":", var.existing_kms_instance_crn), length(split(":", var.existing_kms_instance_crn)) - 3) : tobool("The CRN of the existing KMS is not provided.")
   en_key_name                      = var.prefix != null ? "${var.prefix}-${var.en_key_name}" : var.en_key_name
   en_key_ring_name                 = var.prefix != null ? "${var.prefix}-${var.en_key_ring_name}" : var.en_key_ring_name
@@ -162,7 +162,7 @@ module "event_notifications" {
   kms_endpoint_url          = var.kms_endpoint_url
   existing_kms_instance_crn = local.existing_kms_instance_crn
   root_key_id               = local.en_kms_key_id
-  skip_en_kms_auth_policy   = var.skip_en_kms_auth_policy
+  skip_en_kms_auth_policy   = local.apply_auth_policy == 1 ? true : false
   # COS Related
   cos_integration_enabled = true
   cos_destination_name    = var.cos_destination_name

--- a/solutions/standard/provider.tf
+++ b/solutions/standard/provider.tf
@@ -5,6 +5,6 @@ provider "ibm" {
 
 provider "ibm" {
   alias            = "kms"
-  ibmcloud_api_key = var.ibmcloud_api_key
+  ibmcloud_api_key = var.ibmcloud_kms_api_key != null ? var.ibmcloud_kms_api_key : var.ibmcloud_api_key
   region           = local.kms_region
 }

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -148,7 +148,7 @@ variable "skip_en_kms_auth_policy" {
 
 variable "ibmcloud_kms_api_key" {
   type        = string
-  description = "The API key to use for IBM Cloud in which kms instance is located."
+  description = "The IBM Cloud API key with access to create a root key and key ring in the key management service instance. If the KMS instance is in a different account, specify a key from that account. If not specified, the ibmcloud_api_key variable is used."
   sensitive   = true
   default     = null
 }

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -140,6 +140,13 @@ variable "skip_en_kms_auth_policy" {
   default     = false
 }
 
+variable "ibmcloud_kms_api_key" {
+  type        = string
+  description = "The API key to use for IBM Cloud in which kms instance is located."
+  sensitive   = true
+  default     = null
+}
+
 ########################################################################################################################
 # COS
 ########################################################################################################################


### PR DESCRIPTION
### Description

An external kms key can be used now. If an api key for the external account is passed, new iam policies will be created to all EN and COS to communicate with the external kms instance.

Git Issue: https://github.com/terraform-ibm-modules/terraform-ibm-event-notifications/issues/213

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
