### PR TITLE
fix: updated cbr enforcement mode

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -143,6 +143,12 @@ module "event_notification" {
           {
             name  = "networkZoneId"
             value = module.cbr_vpc_zone.zone_id
+        }]
+        }, {
+        attributes = [
+          {
+            "name" : "endpointType",
+            "value" : "public"
           },
           {
             name  = "networkZoneId"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -84,7 +84,7 @@ resource "ibm_is_subnet" "testacc_subnet" {
 # Create CBR Zone
 ##############################################################################
 
-module "cbr_zone" {
+module "cbr_vpc_zone" {
   source           = "terraform-ibm-modules/cbr/ibm//modules/cbr-zone-module"
   version          = "1.23.0"
   name             = "${var.prefix}-VPC-network-zone"
@@ -93,6 +93,21 @@ module "cbr_zone" {
   addresses = [{
     type  = "vpc",
     value = ibm_is_vpc.example_vpc.crn
+  }]
+}
+
+module "cbr_zone_schematics" {
+  source           = "terraform-ibm-modules/cbr/ibm//modules/cbr-zone-module"
+  version          = "1.23.0"
+  name             = "${var.prefix}-schematics-zone"
+  zone_description = "CBR Network zone containing Schematics"
+  account_id       = data.ibm_iam_account_settings.iam_account_settings.account_id
+  addresses = [{
+    type = "serviceRef",
+    ref = {
+      account_id   = data.ibm_iam_account_settings.iam_account_settings.account_id
+      service_name = "schematics"
+    }
   }]
 }
 
@@ -127,7 +142,11 @@ module "event_notification" {
           },
           {
             name  = "networkZoneId"
-            value = module.cbr_zone.zone_id
+            value = module.cbr_vpc_zone.zone_id
+          },
+          {
+            name  = "networkZoneId"
+            value = module.cbr_zone_schematics.zone_id
         }]
       }]
     }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -117,7 +117,7 @@ module "event_notification" {
   cbr_rules = [
     {
       description      = "${var.prefix}-event notification access only from vpc"
-      enforcement_mode = "report"
+      enforcement_mode = "enabled"
       account_id       = data.ibm_iam_account_settings.iam_account_settings.account_id
       rule_contexts = [{
         attributes = [

--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -38,7 +38,7 @@ resource "ibm_is_subnet" "testacc_subnet" {
 # Create CBR Zone
 ##############################################################################
 
-module "cbr_zone" {
+module "cbr_vpc_zone" {
   source           = "terraform-ibm-modules/cbr/ibm//modules/cbr-zone-module"
   version          = "1.23.0"
   name             = "${var.prefix}-VPC-network-zone"
@@ -142,7 +142,13 @@ module "event_notification" {
           },
           {
             name  = "networkZoneId"
-            value = module.cbr_zone.zone_id
+            value = module.cbr_vpc_zone.zone_id
+        }]
+        }, {
+        attributes = [
+          {
+            "name" : "endpointType",
+            "value" : "private"
           },
           {
             name  = "networkZoneId"

--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -50,6 +50,21 @@ module "cbr_zone" {
   }]
 }
 
+module "cbr_zone_schematics" {
+  source           = "terraform-ibm-modules/cbr/ibm//modules/cbr-zone-module"
+  version          = "1.23.0"
+  name             = "${var.prefix}-schematics-zone"
+  zone_description = "CBR Network zone containing Schematics"
+  account_id       = data.ibm_iam_account_settings.iam_account_settings.account_id
+  addresses = [{
+    type = "serviceRef",
+    ref = {
+      account_id   = data.ibm_iam_account_settings.iam_account_settings.account_id
+      service_name = "schematics"
+    }
+  }]
+}
+
 ##############################################################################
 # Create COS Instance
 ##############################################################################
@@ -128,6 +143,10 @@ module "event_notification" {
           {
             name  = "networkZoneId"
             value = module.cbr_zone.zone_id
+          },
+          {
+            name  = "networkZoneId"
+            value = module.cbr_zone_schematics.zone_id
         }]
       }]
     }

--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -117,7 +117,7 @@ module "event_notification" {
   cbr_rules = [
     {
       description      = "${var.prefix}-event notification access only from vpc"
-      enforcement_mode = "report"
+      enforcement_mode = "enabled"
       account_id       = data.ibm_iam_account_settings.iam_account_settings.account_id
       rule_contexts = [{
         attributes = [

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -40,7 +40,7 @@ module "event_notification" {
   cbr_rules = [
     {
       description      = "Event notification access only from vpc"
-      enforcement_mode = "report"
+      enforcement_mode = "enabled"
       account_id       = "defc0df06b644a9cabc6e44f55b3880s"
       rule_contexts = [{
         attributes = [

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -99,7 +99,6 @@ func TestDAInSchematics(t *testing.T) {
 			"*.tf",
 			solutionDADir + "/*.tf",
 		},
-		ResourceGroup:          resourceGroup,
 		TemplateFolder:         solutionDADir,
 		Tags:                   []string{"test-schematic"},
 		DeleteWorkspaceOnFail:  false,
@@ -109,7 +108,7 @@ func TestDAInSchematics(t *testing.T) {
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 		{Name: "region", Value: region, DataType: "string"},
-		{Name: "resource_group_name", Value: options.ResourceGroup, DataType: "string"},
+		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "kms_endpoint_url", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
 		{Name: "cross_region_location", Value: "us", DataType: "string"},

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -144,7 +144,7 @@ func TestFSCloudInSchematics(t *testing.T) {
 		{Name: "resource_group_name", Value: options.ResourceGroup, DataType: "string"},
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "kms_endpoint_url", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
-		{Name: "root_key_crn", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
+		{Name: "root_key_crn", Value: permanentResources["hpcs_south_root_key_crn"], DataType: "string"},
 	}
 
 	err := options.RunSchematicTest()

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -124,12 +124,9 @@ func TestFSCloudInSchematics(t *testing.T) {
 	var region = validRegions[rand.Intn(len(validRegions))]
 
 	options := testschematic.TestSchematicOptionsDefault(&testschematic.TestSchematicOptions{
-		Testing: t,
-		Prefix:  "en-fs",
-		TarIncludePatterns: []string{
-			"*.tf",
-			fsExampleDir + "/*.tf",
-		},
+		Testing:                t,
+		Prefix:                 "en-fs",
+		TarIncludePatterns:     []string{"*.tf", fsExampleDir + "/*.tf", "modules/fscloud/*.tf"},
 		ResourceGroup:          resourceGroup,
 		TemplateFolder:         fsExampleDir,
 		Tags:                   []string{"test-schematic"},

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -58,16 +58,6 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 	return options
 }
 
-func TestRunCompleteExample(t *testing.T) {
-	t.Parallel()
-
-	options := setupOptions(t, "event-notification-complete", completeExampleDir)
-
-	output, err := options.RunTestConsistency()
-	assert.Nil(t, err, "This should not have errored")
-	assert.NotNil(t, output, "Expected some output")
-}
-
 func TestCompleteExampleInSchematics(t *testing.T) {
 	t.Parallel()
 
@@ -75,7 +65,7 @@ func TestCompleteExampleInSchematics(t *testing.T) {
 
 	options := testschematic.TestSchematicOptionsDefault(&testschematic.TestSchematicOptions{
 		Testing: t,
-		Prefix:  "en-da",
+		Prefix:  "en-complete",
 		TarIncludePatterns: []string{
 			"*.tf",
 			completeExampleDir + "/*.tf",

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -80,7 +80,6 @@ func TestCompleteExampleInSchematics(t *testing.T) {
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 		{Name: "prefix", Value: options.Prefix, DataType: "string"},
-		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
 		{Name: "region", Value: region, DataType: "string"},
 	}
 
@@ -125,9 +124,13 @@ func TestFSCloudInSchematics(t *testing.T) {
 	var region = validRegions[rand.Intn(len(validRegions))]
 
 	options := testschematic.TestSchematicOptionsDefault(&testschematic.TestSchematicOptions{
-		Testing:                t,
-		Prefix:                 "en-fs",
-		TarIncludePatterns:     []string{"*.tf", fsExampleDir + "/*.tf", "modules/fscloud/*.tf"},
+		Testing: t,
+		Prefix:  "en-fs",
+		TarIncludePatterns: []string{
+			"*.tf",
+			fsExampleDir + "/*.tf",
+			"modules/fscloud/*.tf",
+		},
 		ResourceGroup:          resourceGroup,
 		TemplateFolder:         fsExampleDir,
 		Tags:                   []string{"test-schematic"},
@@ -139,7 +142,6 @@ func TestFSCloudInSchematics(t *testing.T) {
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 		{Name: "region", Value: region, DataType: "string"},
 		{Name: "prefix", Value: options.Prefix, DataType: "string"},
-		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "kms_endpoint_url", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
 		{Name: "root_key_crn", Value: permanentResources["hpcs_south_root_key_crn"], DataType: "string"},

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -157,15 +157,14 @@ func TestRunUpgradeDASolution(t *testing.T) {
 	var region = validRegions[rand.Intn(len(validRegions))]
 
 	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  solutionDADir,
-		Prefix:        "en-da-upg",
-		ResourceGroup: resourceGroup,
+		Testing:      t,
+		TerraformDir: solutionDADir,
+		Prefix:       "en-da-upg",
 	})
 
 	terraformVars := map[string]interface{}{
 		"ibmcloud_api_key":                    options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"],
-		"resource_group_name":                 options.ResourceGroup,
+		"resource_group_name":                 options.Prefix,
 		"region":                              region,
 		"existing_kms_instance_crn":           permanentResources["hpcs_south_crn"],
 		"existing_kms_root_key_crn":           permanentResources["hpcs_south_root_key_crn"],

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -55,20 +55,6 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 		Region:        validRegions[rand.Intn(len(validRegions))],
 	})
 
-	if dir == fsExampleDir {
-		options = testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-			Testing:       t,
-			TerraformDir:  dir,
-			Prefix:        prefix,
-			ResourceGroup: resourceGroup,
-			Region:        options.Region,
-			TerraformVars: map[string]interface{}{
-				"existing_kms_instance_crn": permanentResources["hpcs_south_crn"],
-				"root_key_crn":              permanentResources["hpcs_south_root_key_crn"],
-				"kms_endpoint_url":          permanentResources["hpcs_south_private_endpoint"],
-			},
-		})
-	}
 	return options
 }
 
@@ -82,14 +68,33 @@ func TestRunCompleteExample(t *testing.T) {
 	assert.NotNil(t, output, "Expected some output")
 }
 
-func TestRunFSCloudExample(t *testing.T) {
+func TestCompleteExampleInSchematics(t *testing.T) {
 	t.Parallel()
 
-	options := setupOptions(t, "en-fs", fsExampleDir)
+	var region = validRegions[rand.Intn(len(validRegions))]
 
-	output, err := options.RunTestConsistency()
+	options := testschematic.TestSchematicOptionsDefault(&testschematic.TestSchematicOptions{
+		Testing: t,
+		Prefix:  "en-da",
+		TarIncludePatterns: []string{
+			"*.tf",
+			completeExampleDir + "/*.tf",
+		},
+		ResourceGroup:          resourceGroup,
+		TemplateFolder:         solutionDADir,
+		Tags:                   []string{"test-schematic"},
+		DeleteWorkspaceOnFail:  false,
+		WaitJobCompleteMinutes: 60,
+	})
+
+	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
+		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
+		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
+		{Name: "region", Value: region, DataType: "string"},
+	}
+
+	err := options.RunSchematicTest()
 	assert.Nil(t, err, "This should not have errored")
-	assert.NotNil(t, output, "Expected some output")
 }
 
 func TestDAInSchematics(t *testing.T) {
@@ -118,6 +123,38 @@ func TestDAInSchematics(t *testing.T) {
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "kms_endpoint_url", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
 		{Name: "cross_region_location", Value: "us", DataType: "string"},
+	}
+
+	err := options.RunSchematicTest()
+	assert.Nil(t, err, "This should not have errored")
+}
+
+func TestFSCloudInSchematics(t *testing.T) {
+	t.Parallel()
+
+	var region = validRegions[rand.Intn(len(validRegions))]
+
+	options := testschematic.TestSchematicOptionsDefault(&testschematic.TestSchematicOptions{
+		Testing: t,
+		Prefix:  "en-fs",
+		TarIncludePatterns: []string{
+			"*.tf",
+			fsExampleDir + "/*.tf",
+		},
+		ResourceGroup:          resourceGroup,
+		TemplateFolder:         fsExampleDir,
+		Tags:                   []string{"test-schematic"},
+		DeleteWorkspaceOnFail:  false,
+		WaitJobCompleteMinutes: 60,
+	})
+
+	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
+		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
+		{Name: "region", Value: region, DataType: "string"},
+		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
+		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
+		{Name: "kms_endpoint_url", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
+		{Name: "root_key_crn", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
 	}
 
 	err := options.RunSchematicTest()

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -79,6 +79,7 @@ func TestCompleteExampleInSchematics(t *testing.T) {
 
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
+		{Name: "resource_group_name", Value: options.ResourceGroup, DataType: "string"},
 		{Name: "region", Value: region, DataType: "string"},
 	}
 
@@ -108,6 +109,7 @@ func TestDAInSchematics(t *testing.T) {
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 		{Name: "region", Value: region, DataType: "string"},
+		{Name: "resource_group_name", Value: options.ResourceGroup, DataType: "string"},
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "kms_endpoint_url", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
 		{Name: "cross_region_location", Value: "us", DataType: "string"},
@@ -139,6 +141,7 @@ func TestFSCloudInSchematics(t *testing.T) {
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 		{Name: "region", Value: region, DataType: "string"},
+		{Name: "resource_group_name", Value: options.ResourceGroup, DataType: "string"},
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "kms_endpoint_url", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
 		{Name: "root_key_crn", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
@@ -154,14 +157,15 @@ func TestRunUpgradeDASolution(t *testing.T) {
 	var region = validRegions[rand.Intn(len(validRegions))]
 
 	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
-		Testing:      t,
-		TerraformDir: solutionDADir,
-		Prefix:       "en-da-upg",
+		Testing:       t,
+		TerraformDir:  solutionDADir,
+		Prefix:        "en-da-upg",
+		ResourceGroup: resourceGroup,
 	})
 
 	terraformVars := map[string]interface{}{
 		"ibmcloud_api_key":                    options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"],
-		"resource_group_name":                 options.Prefix,
+		"resource_group_name":                 options.ResourceGroup,
 		"region":                              region,
 		"existing_kms_instance_crn":           permanentResources["hpcs_south_crn"],
 		"existing_kms_root_key_crn":           permanentResources["hpcs_south_root_key_crn"],

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -71,7 +71,7 @@ func TestCompleteExampleInSchematics(t *testing.T) {
 			completeExampleDir + "/*.tf",
 		},
 		ResourceGroup:          resourceGroup,
-		TemplateFolder:         solutionDADir,
+		TemplateFolder:         completeExampleDir,
 		Tags:                   []string{"test-schematic"},
 		DeleteWorkspaceOnFail:  false,
 		WaitJobCompleteMinutes: 60,
@@ -79,7 +79,6 @@ func TestCompleteExampleInSchematics(t *testing.T) {
 
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
-		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
 		{Name: "region", Value: region, DataType: "string"},
 	}
 
@@ -108,7 +107,6 @@ func TestDAInSchematics(t *testing.T) {
 
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
-		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
 		{Name: "region", Value: region, DataType: "string"},
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "kms_endpoint_url", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
@@ -141,7 +139,6 @@ func TestFSCloudInSchematics(t *testing.T) {
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 		{Name: "region", Value: region, DataType: "string"},
-		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "kms_endpoint_url", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
 		{Name: "root_key_crn", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -79,7 +79,8 @@ func TestCompleteExampleInSchematics(t *testing.T) {
 
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
-		{Name: "resource_group_name", Value: options.ResourceGroup, DataType: "string"},
+		{Name: "prefix", Value: options.Prefix, DataType: "string"},
+		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
 		{Name: "region", Value: region, DataType: "string"},
 	}
 
@@ -137,7 +138,8 @@ func TestFSCloudInSchematics(t *testing.T) {
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 		{Name: "region", Value: region, DataType: "string"},
-		{Name: "resource_group_name", Value: options.ResourceGroup, DataType: "string"},
+		{Name: "prefix", Value: options.Prefix, DataType: "string"},
+		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "kms_endpoint_url", Value: permanentResources["hpcs_south_private_endpoint"], DataType: "string"},
 		{Name: "root_key_crn", Value: permanentResources["hpcs_south_root_key_crn"], DataType: "string"},


### PR DESCRIPTION
### Description

Update the CBR enforcement mode to enabled as the report is not supported. This is newly introduced SMTP API  in EN that does not support monitoring.
[Git Issue](https://github.com/terraform-ibm-modules/terraform-ibm-event-notifications/issues/250)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
