### PR TITLE
update to COS 8.14.1 to pull in auth policy scope changes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-13T05:17:42Z",
+  "generated_at": "2023-12-14T05:17:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -249,7 +249,7 @@ locals {
 module "cos" {
   count                               = local.create_cos_bucket ? 1 : 0
   source                              = "terraform-ibm-modules/cos/ibm"
-  version                             = "8.12.0"
+  version                             = "8.14.0"
   create_cos_instance                 = var.existing_cos_instance_crn == null ? true : false
   create_cos_bucket                   = local.create_cos_bucket
   existing_cos_instance_id            = var.existing_cos_instance_crn

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -249,7 +249,7 @@ locals {
 module "cos" {
   count                               = local.create_cos_bucket ? 1 : 0
   source                              = "terraform-ibm-modules/cos/ibm"
-  version                             = "8.14.0"
+  version                             = "8.14.1"
   create_cos_instance                 = var.existing_cos_instance_crn == null ? true : false
   create_cos_bucket                   = local.create_cos_bucket
   existing_cos_instance_id            = var.existing_cos_instance_crn

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -210,7 +210,7 @@ func TestRunUpgradeDASolution(t *testing.T) {
 		"resource_group_name":                 options.Prefix,
 		"region":                              region,
 		"existing_kms_instance_crn":           permanentResources["hpcs_south_crn"],
-		"kms_endpoint_url":                    permanentResources["hpcs_south_private_endpoint"],
+		"kms_endpoint_url":                    permanentResources["hpcs_south_public_endpoint"],
 		"management_endpoint_type_for_bucket": "public",
 	}
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -211,6 +211,7 @@ func TestRunUpgradeDASolution(t *testing.T) {
 		"region":                              region,
 		"existing_kms_instance_crn":           permanentResources["hpcs_south_crn"],
 		"kms_endpoint_url":                    permanentResources["hpcs_south_public_endpoint"],
+		"kms_endpoint_type":                   "public",
 		"management_endpoint_type_for_bucket": "public",
 	}
 


### PR DESCRIPTION
### Description

update to COS 8.14.1 to pull in auth policy scope changes

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
