### PR TITLE
fix: fix KMS integration, cleanup and provider version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To create service credentials, access the Event Notifications service, and acces
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.70.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.76.0, < 2.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 
 ### Modules

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.70.0"
+      version = "1.76.0"
     }
   }
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -7,5 +7,4 @@ An end-to-end example that creates the following infrastructure:
 - An Event Notifications instance with bring-your-own-key encryption.
 - An IBM Cloud Object Storage service instance and bucket to collect events that fail delivery.
 - A Virtual Private Cloud (VPC).
-- A context-based restriction (CBR) rule to allow Event Notifications to be accessible from VPC and Schematics.
 - Service credentials for the Event Notifications instance.

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -17,7 +17,7 @@ variable "resource_group" {
 variable "prefix" {
   type        = string
   description = "Prefix to append to all resources created by this example"
-  default     = "complete"
+  default     = "co-sky11"
 }
 
 variable "resource_tags" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -17,7 +17,7 @@ variable "resource_group" {
 variable "prefix" {
   type        = string
   description = "Prefix to append to all resources created by this example"
-  default     = "co-sky11"
+  default     = "complete"
 }
 
 variable "resource_tags" {

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.70.0, < 2.0.0"
+      version = ">= 1.76.0, < 2.0.0"
     }
   }
 }

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.70.0, < 2.0.0"
+      version = ">= 1.76.0, < 2.0.0"
     }
   }
 }

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -64,7 +64,7 @@ module "event_notification" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.70.0, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.76.0, <2.0.0 |
 
 ### Modules
 

--- a/modules/fscloud/version.tf
+++ b/modules/fscloud/version.tf
@@ -7,7 +7,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.70.0, <2.0.0"
+      version = ">= 1.76.0, <2.0.0"
     }
   }
 }

--- a/solutions/standard/version.tf
+++ b/solutions/standard/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.75.2"
+      version = "1.76.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/version.tf
+++ b/version.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.70.0, < 2.0.0"
+      version = ">= 1.76.0, < 2.0.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
### Description

- Provider version update for EN pointing to incorrect kms key.
- Removed CBR from complete example as FScloud example containes CBR.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
