### PR TITLE
fix: cos direct endpoint

### DIFF
--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -129,7 +129,7 @@ module "event_notification" {
   cos_bucket_name         = module.cos.buckets[local.bucket_name].bucket_name
   cos_instance_id         = module.cos.cos_instance_crn
   skip_en_cos_auth_policy = false
-  cos_endpoint            = "https://${module.cos.buckets[local.bucket_name].s3_endpoint_private}"
+  cos_endpoint            = "https://${module.cos.buckets[local.bucket_name].s3_endpoint_direct}"
   cbr_rules = [
     {
       description      = "${var.prefix}-event notification access from vpc and schematics"

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -35,9 +35,8 @@ const yamlLocation = "../common-dev-assets/common-go-assets/common-permanent-res
 // Current supported EN region
 var validRegions = []string{
 	"us-south",
-	// 	Error occurring specific to eu-de/eu-de regions, see https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6221
-	// 	"eu-de",
-	// 	"eu-es",
+	"eu-de",
+	"eu-es",
 	"eu-gb",
 	"au-syd",
 }


### PR DESCRIPTION
### Description

`eu-de` and `eu-es` regions recently has been migrated to VPC infra (DN environment) hence COS private endpoint now cannot be used, only direct and public endpoints can be used.
Git Issue:
Intermittent frequent issue during apply - ibm_en_integration_cos failure in eu-de and eu-es regions.
TF provider [issue](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6221) for reference.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Update COS endpoint to direct.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
